### PR TITLE
Glyph handling updates

### DIFF
--- a/libpgf-csharp/DLLInterface.cs
+++ b/libpgf-csharp/DLLInterface.cs
@@ -5,10 +5,10 @@ namespace libpgf_csharp
 {
     internal static class DLLInterface
     {
-        [DllImport("libpgfglyph.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libpgfdll.dll", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr LoadFont(string fileName);
 
-        [DllImport("libpgfglyph.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libpgfdll.dll", CallingConvention = CallingConvention.Cdecl)]
         public static extern bool SaveFont(IntPtr fontPtr, string FileName);
     }
 }

--- a/libpgf-csharp/PGFFont.cs
+++ b/libpgf-csharp/PGFFont.cs
@@ -63,14 +63,33 @@ namespace libpgf_csharp
             return DLLInterface.SaveFont(fontPtr, fileName);
         }
 
+        /// <summary>
+        /// Attempt to get glyph by index - returns null on failure
+        /// </summary>
         public PGFGlyph GetGlyphByIndex(int index)
         {
-            return glyphs[index];
+            if (index < glyphs.Length)
+            {
+                return glyphs[index];
+            }
+
+            return null;
         }
 
+        /// <summary>
+        /// Attempt to get glyph by index - returns null on failure
+        /// </summary>
         public PGFGlyph GetGlyphByUcs(int ucs)
         {
-            return ucsDict[ucs];
+            PGFGlyph glyph;
+            bool success = ucsDict.TryGetValue(ucs, out glyph);
+
+            if (success)
+            {
+                return ucsDict[ucs];
+            }
+
+            return null;
         }
 
         private void LoadGlyphs()


### PR DESCRIPTION
The constant exceptions thrown when trying to pre-build a cache of all glpyhs by iterating through all possible ucs/index lead to a large performance penalty. This avoids that by checking if the glyph has a corresponding entry before trying to access it.

The DLL name is also updated in this PR.